### PR TITLE
add isomorphic-fetch to package.json

### DIFF
--- a/example/package.json
+++ b/example/package.json
@@ -6,7 +6,8 @@
     "start": "AWSIOT_CONFIG_FILE=./config.json NODE_RED_DIR=./node-red enebular-awsiot-agent"
   },
   "dependencies": {
-  	"node-red": "^0.13.4",
+    "node-red": "^0.13.4",
+    "isomorphic-fetch": "matthew-andrews/isomorphic-fetch",
     "enebular-awsiot-agent": "enebular/enebular-awsiot-agent"
   }
 }


### PR DESCRIPTION
lack of `isomorphic-fetch` courses an error

```
~/example$ npm start

> enebular-awsiot-agent-example@1.0.0 start /home/ubuntu/enebular-poc
> AWSIOT_CONFIG_FILE=./config.json NODE_RED_DIR=./node-red enebular-awsiot-agent

module.js:327
    throw err;
    ^

Error: Cannot find module 'isomorphic-fetch'
    at Function.Module._resolveFilename (module.js:325:15)
    at Function.Module._load (module.js:276:25)
    at Module.require (module.js:353:17)
    at require (internal/module.js:12:17)
    at Object.<anonymous> (/home/ubuntu/enebular-poc/node_modules/enebular-awsiot-agent/lib/index.js:52:24)
    at Module._compile (module.js:409:26)
    at Object.Module._extensions..js (module.js:416:10)
    at Module.load (module.js:343:32)
    at Function.Module._load (module.js:300:12)
    at Module.require (module.js:353:17)
```